### PR TITLE
changed shebang

### DIFF
--- a/sign-modules.sh
+++ b/sign-modules.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 MOK=modules_signing
 #declare -A MODULES


### PR DESCRIPTION
On Debian buster, an error occurs when using sh:

./sign-modules.sh: 57: ./sign-modules.sh: Syntax error: "(" unexpected (expecting ";;")

Using bash, the script works fine!

Hence, I would change the shebang to 
#/bin/bash